### PR TITLE
Bump to CUDA.jl v6 (subpackages)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.3.0"
 
 [deps]
 Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CUDACore = "bd0ed864-bdfe-4181-a5ed-ce625a5fdea2"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -14,11 +14,14 @@ MadNLPGPU = "d72a61cc-809d-412f-99be-fd81f4b8a598"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+cuSPARSE = "b26da814-b3bc-49ef-b0ee-c816305aa060"
 
 [compat]
+CUDACore = "6"
 Krylov = "0.10.1"
 MadNLP = "0.9"
 MadNLPGPU = "0.8"
+cuSPARSE = "6"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ cuSPARSE = "b26da814-b3bc-49ef-b0ee-c816305aa060"
 CUDACore = "6"
 Krylov = "0.10.1"
 MadNLP = "0.9"
-MadNLPGPU = "0.8"
+MadNLPGPU = "0.9"
 cuSPARSE = "6"
 julia = "1.10"
 

--- a/src/HybridKKT.jl
+++ b/src/HybridKKT.jl
@@ -10,7 +10,8 @@ import MadNLP
 import MadNLPGPU
 import MadNLP: SparseMatrixCOO, full
 
-using CUDA
+using CUDACore
+using cuSPARSE
 using KernelAbstractions
 import Atomix
 

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -84,7 +84,7 @@ end
         Atomix.@atomic valsG[to_map[k]] += valJ[fr_map[k]]
     end
 end
-function transfer_coef!(G::CUSPARSE.CuSparseMatrixCSC, map::CuVector{Int}, coefs::CuVector{Tv}, ind_eq) where Tv
+function transfer_coef!(G::cuSPARSE.CuSparseMatrixCSC, map::CuVector{Int}, coefs::CuVector{Tv}, ind_eq) where Tv
     valsG = nonzeros(G)
     fill!(valsG, zero(Tv))
     _transfer_coef_kernel!(CUDABackend())(valsG, map, coefs, ind_eq; ndrange=length(map))

--- a/src/kkt.jl
+++ b/src/kkt.jl
@@ -421,7 +421,7 @@ end
     GPU specific code (require MadNLPGPU).
 =#
 
-function MadNLP.compress_hessian!(kkt::HybridCondensedKKTSystem{T, VT, MT}) where {T, VT, MT<:CUDA.CUSPARSE.CuSparseMatrixCSC{T, Int32}}
+function MadNLP.compress_hessian!(kkt::HybridCondensedKKTSystem{T, VT, MT}) where {T, VT, MT<:cuSPARSE.CuSparseMatrixCSC{T, Int32}}
     fill!(kkt.hess_com.nzVal, zero(T))
     if length(kkt.ext.hess_com_ptrptr) > 1
         MadNLPGPU._transfer_to_csc_kernel!(CUDABackend())(
@@ -435,7 +435,7 @@ function MadNLP.compress_hessian!(kkt::HybridCondensedKKTSystem{T, VT, MT}) wher
     end
 end
 
-function MadNLP.compress_jacobian!(kkt::HybridCondensedKKTSystem{T, VT, MT}) where {T, VT, MT<:CUDA.CUSOLVER.CuSparseMatrixCSC{T, Int32}}
+function MadNLP.compress_jacobian!(kkt::HybridCondensedKKTSystem{T, VT, MT}) where {T, VT, MT<:cuSPARSE.CuSparseMatrixCSC{T, Int32}}
     fill!(kkt.jt_csc.nzVal, zero(T))
     if length(kkt.ext.jt_csc_ptrptr) > 1 # otherwise error is thrown
         MadNLPGPU._transfer_to_csc_kernel!(CUDABackend())(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,7 @@
 macro elapsed_hykkt(ex)
-    if CUDA.functional()
+    if CUDACore.functional()
         quote
-            CUDA.@elapsed $(esc(ex))
+            CUDACore.@elapsed $(esc(ex))
         end
     else
         quote

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using CUDA
+using CUDACore
 using ExaModels
 using HybridKKT
 using LinearAlgebra
@@ -119,7 +119,7 @@ end
     test_hybrid_kkt_cpu(nlp, linear_solver)
 end
 
-if CUDA.functional()
+if CUDACore.functional()
     @testset "[GPU] HybridCondensedKKTSystem" begin
         nlp = elec_model(5; backend=CUDABackend())
         linear_solver = MadNLPGPU.LapackCUDASolver
@@ -156,7 +156,7 @@ end
         @test stats.solution ≈ stats_ref.solution atol=1e-6
     end
 
-    if CUDA.functional()
+    if CUDACore.functional()
         nlp_gpu = elec_model(5; backend=CUDABackend())
         @testset "[CUDA] LapackCUDASolver" begin
             solver = MadNLPSolver(


### PR DESCRIPTION
Should wait for merge/release [MadNLPGPU PR #614](https://github.com/MadNLP/MadNLP.jl/pull/614).

AI generated:

Replace the CUDA meta-package dependency with direct deps on the
subpackages we actually use: CUDACore (for `functional`, `@elapsed`,
`CuVector`, `CUDABackend`) and cuSPARSE (for `CuSparseMatrixCSC`).
Compat pinned to CUDA.jl v6 lockstep version (= "6").

The `compress_jacobian!` GPU overload previously matched on
`CUDA.CUSOLVER.CuSparseMatrixCSC`, an aliased re-import that resolved
to the same type as `CUSPARSE.CuSparseMatrixCSC`; routed through
cuSPARSE for consistency with the rest of the migration.